### PR TITLE
ZCS-1298 must login every time browser restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+.project
+.classpath

--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -194,7 +194,7 @@ public class LoginTag extends ZimbraSimpleTag {
             String refer = mbox.getAuthResult().getRefer();
             boolean needRefer = (refer != null && !refer.equalsIgnoreCase(serverName));
 
-            if ((mAuthToken == null || mAuthTokenInUrl || mTwoFactorCode != null) && !needRefer) {
+            if ((mAuthToken == null || mAuthTokenInUrl || (mTwoFactorCode != null && mTwoFactorCode.length() > 0)) && !needRefer) {
                 //Rewrite the ZM_AUTH_TOKEN cookie in case of successful two factor authentication
                 setCookie(response,
                         mbox.getAuthToken(),


### PR DESCRIPTION
https://bugzilla.zimbra.com/show_bug.cgi?id=107105
- login.jsp passes twoFactorCode as empty string so check for that value as well additional to null check to make sure we are not rewriting cookie in case of normal user/password based login