### PR TITLE
ZCS-1366 Session not invalidated on server after logout in admin console

### DIFF
--- a/META-INF/zm.tld
+++ b/META-INF/zm.tld
@@ -1327,6 +1327,14 @@
         <name>logout</name>
         <tag-class>com.zimbra.cs.taglib.tag.LogoutTag</tag-class>
         <body-content>empty</body-content>
+        <attribute>
+            <description>
+                Identify admin console is generating this request or webclient
+            </description>
+            <name>isAdmin</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
     </tag>
 
     <tag>

--- a/src/java/com/zimbra/cs/taglib/tag/LogoutTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LogoutTag.java
@@ -19,6 +19,7 @@ package com.zimbra.cs.taglib.tag;
 import java.io.IOException;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspContext;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspTagException;
@@ -27,6 +28,7 @@ import javax.servlet.jsp.PageContext;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraCookie;
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.account.AuthTokenException;
@@ -36,31 +38,51 @@ import com.zimbra.cs.taglib.ZJspSession;
 
 public class LogoutTag extends ZimbraSimpleTag {
 
+    private boolean mIsAdmin = false;
+
+    public void setIsAdmin(boolean isAdmin) { this.mIsAdmin = isAdmin; }
+
     @Override
     public void doTag() throws JspException, IOException {
         JspContext jctxt = getJspContext();
         PageContext pageContext = (PageContext) jctxt;
-        ZAuthToken authToken = ZJspSession.getAuthToken(pageContext);
+        HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();
+        ZAuthToken authToken;
+
+        // Admin console doesn't maintain auth token in jsp session so get it from request object
+        if(mIsAdmin == true) {
+            authToken = new ZAuthToken(request, true);
+        } else {
+            authToken = ZJspSession.getAuthToken(pageContext);
+        }
+
         try {
-        	if(authToken != null) {
-        		AuthToken at = ZimbraAuthToken.getAuthToken(authToken.getValue());
-        		Account acc = at.getAccount();
-        		if(at != null && acc != null) {
+            if(authToken != null && authToken.getValue() != null) {
+                AuthToken at = ZimbraAuthToken.getAuthToken(authToken.getValue());
+                Account acc = at.getAccount();
+                if(at != null && acc != null) {
                     //Force a authRequest with csrfSupported=1 to get the csrfToken. EndSessionRequest would need it.
-    		        ZMailbox mbox = ZMailbox.getByAuthToken(authToken, URLUtil.getSoapURL(acc.getServer(), false), true, true);
-    		        mbox.logout();//this invalidates the session in mailbox app
-        		}
-        	}
+                    ZMailbox mbox = ZMailbox.getByAuthToken(authToken, URLUtil.getSoapURL(acc.getServer(), false), true, true);
+                    mbox.logout();//this invalidates the session in mailbox app
+                }
+            }
         } catch (ServiceException e) {
             if (!ServiceException.AUTH_EXPIRED.equals(e.getCode())) { //don't throw an exception if this token has already been invalidated
                 throw new JspTagException(e.getMessage(), e);
             }
-		} catch (AuthTokenException e) {
-		    throw new JspTagException(e.getMessage(), e);
+        } catch (AuthTokenException e) {
+            throw new JspTagException(e.getMessage(), e);
         } finally {
-	        HttpServletResponse response = (HttpServletResponse) pageContext.getResponse();
-	        ZAuthToken.clearCookies(response);
-	        ZJspSession.clearSession(pageContext);
-		}
+            HttpServletResponse response = (HttpServletResponse) pageContext.getResponse();
+            // admin console cookie is not getting cleared by ZAuthToken.clearCookies, so manually do it here
+            if(mIsAdmin == true) {
+                ZimbraCookie.clearCookie(response, ZimbraCookie.COOKIE_ZM_ADMIN_AUTH_TOKEN);
+                ZimbraCookie.clearCookie(response, "JSESSIONID");
+            } else {
+            	ZAuthToken.clearCookies(response);
+            }
+
+            ZJspSession.clearSession(pageContext);
+        }
     }
 }


### PR DESCRIPTION
- make LogoutTag.java compatible to be used in admin console also
- admin console doesn't store auth token in jsp session (as admin console is not using LoginTag.java) so essentially we needed to get the auth token from request object
- if admin console is using this tag then make sure it only clears ZM_ADMIN_AUTH_TOKEN and JSESSIONID, as opposed to webclient where we are using ZAuthToken.clearCookies which clears lot many cookies
- another reason for not using ZAuthToken.clearCookies is we don't want to clear ZM_AUTH_TOKEN which is used by webclient, so user may have selected remember me option and we are removing the cookie then it will be a bad thing to do