### PR TITLE
ZCS-817 unexpected logout happening in html client

### DIFF
--- a/src/java/com/zimbra/cs/taglib/ZJspSession.java
+++ b/src/java/com/zimbra/cs/taglib/ZJspSession.java
@@ -506,10 +506,8 @@ public class ZJspSession {
         if (authToken == null || authToken.isEmpty()) {
             return null;
         } else {
-            // For non-GET (POST) requests don't request the csrf token because those requests are likely not
-            // originating via standard navigation inside browser and could possibly be CSRF attack vectors
-            ZMailbox.Options options = new ZMailbox.Options(authToken, getSoapURL(context), true,
-                    "GET".equals(((HttpServletRequest) context.getRequest()).getMethod()));
+            // Force a authRequest with csrfSupported=1 so that the generated mailbox object has csrfToken.
+            ZMailbox.Options options = new ZMailbox.Options(authToken, getSoapURL(context), true, true);
             options.setClientIp(getRemoteAddr(context));
             ZMailbox mbox = ZMailbox.getMailbox(options);
             mbox.getAccountInfo(false);


### PR DESCRIPTION
Issue:
 - html client has jsp session timeout of 5 mins, so after that it needs to recreate jsp session based on valid authtoken but we had code that sets csrfSupported to false if request type is POST

 Resolution:
 - zm-taglib: ZJspSession.java, revert back change which checked request type for setting csrfSupported flag, which was done to fix https://bugzilla.zimbra.com/show_bug.cgi?id=104828 issue, I think we should blindly not consider all POST requests as CSRF vectors
 - zm-web-client: newBriefCheck.tag & briefcaseListViewToolbar.tag, properly fix https://bugzilla.zimbra.com/show_bug.cgi?id=104828 by checking for valid crumb when trying to upload briefcase attachment