### PR TITLE
Bugfix/zcs 2972

### DIFF
--- a/META-INF/zm.tld
+++ b/META-INF/zm.tld
@@ -7317,6 +7317,12 @@
     </function>
 
     <function>
+        <name>buildRedirectURL</name>
+        <function-class>com.zimbra.cs.taglib.ZJspSession</function-class>
+        <function-signature>java.lang.String buildRedirectURL(javax.servlet.jsp.PageContext, java.lang.String)</function-signature>
+    </function>
+
+    <function>
         <name>getChangePasswordUrl</name>
         <function-class>com.zimbra.cs.taglib.ZJspSession</function-class>
         <function-signature>java.lang.String getChangePasswordUrl(javax.servlet.jsp.PageContext,java.lang.String)</function-signature>

--- a/META-INF/zm.tld
+++ b/META-INF/zm.tld
@@ -14,7 +14,7 @@
         <description>sends a message</description>
         <name>sendMessage</name>
         <tag-class>com.zimbra.cs.taglib.tag.SendMessageTag</tag-class>
-        <body-content>empty</body-content>        
+        <body-content>empty</body-content>
         <variable>
             <name-from-attribute>var</name-from-attribute>
             <variable-class>com.zimbra.client.ZMailbox.ZSendMessageResponse</variable-class>
@@ -204,7 +204,7 @@
              <required>false</required>
              <rtexprvalue>true</rtexprvalue>
              <type>com.zimbra.cs.taglib.bean.ZMessageComposeBean</type>
-         </attribute>        
+         </attribute>
         <attribute>
             <description>
                 value of To addresses
@@ -399,7 +399,7 @@
             <rtexprvalue>true</rtexprvalue>
             <type>java.lang.String</type>
         </attribute>
-        
+
         <attribute>
             <description>
                 exception invite id if editing exception
@@ -823,7 +823,7 @@
             </description>
             <name>expanded</name>
             <required>false</required>
-            <rtexprvalue>true</rtexprvalue>            
+            <rtexprvalue>true</rtexprvalue>
             <type>java.util.Map</type>
         </attribute>
     </tag>
@@ -1498,11 +1498,11 @@
                  s - include items in the user's Sent folder (not necessarily "Sent")<br />
                  o - include items in any other folder<br />
                  a leading '-' means to negate the constraint (e.g. "-t" means all messages not in Trash)<br />
-               ]]>                 
+               ]]>
              </description>
              <name>tc</name>
              <required>false</required>
-             <rtexprvalue>true</rtexprvalue>             
+             <rtexprvalue>true</rtexprvalue>
              <type>java.lang.String</type>
          </attribute>
 
@@ -1670,7 +1670,7 @@
             <name>id</name>
             <required>true</required>
             <rtexprvalue>true</rtexprvalue>
-            <type>java.lang.String</type>            
+            <type>java.lang.String</type>
         </attribute>
          <attribute>
              <description>flag state (true=flagged, false=unflagged)</description>
@@ -1799,7 +1799,7 @@
             <type>boolean</type>
         </attribute>
     </tag>
-    
+
     <tag>
         <description>
             Mark a conversation as spam/unspam, and optionally move to a specific folder.
@@ -2176,7 +2176,7 @@
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
-        
+
         <attribute>
             <description>contact ids</description>
             <name>contactIds</name>
@@ -2438,7 +2438,7 @@
          <attribute>
              <description>allow unknown contact fields to used</description>
              <name>force</name>
-             <required>false</required>             
+             <required>false</required>
              <rtexprvalue>true</rtexprvalue>
              <type>boolean</type>
          </attribute>
@@ -2479,7 +2479,7 @@
          <attribute>
              <description>replace (true) or merge modify fields with contact</description>
              <name>replace</name>
-             <required>false</required>             
+             <required>false</required>
              <rtexprvalue>true</rtexprvalue>
              <type>boolean</type>
          </attribute>
@@ -2680,7 +2680,7 @@
             <description>the exception</description>
             <name>exception</name>
             <required>true</required>
-            <rtexprvalue>true</rtexprvalue>            
+            <rtexprvalue>true</rtexprvalue>
         </attribute>
     </tag>
 
@@ -2740,7 +2740,7 @@
             <name>restauthtokenobject</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
-        </attribute>        
+        </attribute>
         <attribute>
             <description>
                 target account id for use with REST HTML rendering.
@@ -3183,7 +3183,7 @@
            <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
-        
+
         <attribute>
             <description>mark message as read</description>
             <name>markread</name>
@@ -3312,7 +3312,7 @@
             <name>id</name>
             <required>true</required>
             <rtexprvalue>true</rtexprvalue>
-            <type>java.lang.String</type>            
+            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>new tag name</description>
@@ -3348,7 +3348,7 @@
             <name>id</name>
             <required>true</required>
             <rtexprvalue>true</rtexprvalue>
-            <type>java.lang.String</type>            
+            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>color of tag: orange, blue, cyan, green, purple, red, yellow</description>
@@ -3497,7 +3497,7 @@
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
             <type>java.lang.String</type>
-        </attribute>        
+        </attribute>
     </tag>
 
     <tag>
@@ -4058,7 +4058,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
-            <description>sort order (dateDesc, dateAsc, subjDesc, subjAsc)</description>            
+            <description>sort order (dateDesc, dateAsc, subjDesc, subjAsc)</description>
             <name>sort</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
@@ -4759,7 +4759,7 @@
             <type>java.lang.String</type>
         </attribute>
     </tag>
-    
+
     <tag>
         <description>
            get appointments that fall with the specified range.
@@ -5017,7 +5017,7 @@
     <tag>
         <description>
             Iterates over an appointment list. If start and end are specified,
-            only return appointments within that range.  
+            only return appointments within that range.
         </description>
         <name>forEachAppoinment</name>
         <tag-class>com.zimbra.cs.taglib.tag.calendar.ForEachAppointmentTag</tag-class>
@@ -5564,7 +5564,7 @@
             <rtexprvalue>true</rtexprvalue>
         </attribute>
     </tag>
-    
+
     <tag>
         <description>Save attachments as documents to a briefcase folder</description>
         <name>saveAttachmentsToBriefcase</name>
@@ -5585,7 +5585,7 @@
         </attribute>
         <attribute>
             <description>
-                Part id 
+                Part id
             </description>
             <name>partId</name>
             <rtexprvalue>true</rtexprvalue>
@@ -6305,7 +6305,7 @@
 
   <tag>
         <description>
-    	    Interface for ZPhone    
+           Interface for ZPhone
         </description>
 
         <name>phone</name>
@@ -6829,7 +6829,7 @@
             <rtexprvalue>true</rtexprvalue>
             <type>java.lang.String</type>
         </attribute>
-	
+
 	<attribute>
             <description>
                 Map to edit
@@ -6918,7 +6918,7 @@
             <rtexprvalue>true</rtexprvalue>
         </attribute>
     </tag>
-    
+
 	<!-- These tags are copied from jstl.tld because we implement our own
 	     versions but want to keep API compatibility. -->
 	<!--
@@ -7119,7 +7119,7 @@
             </c:if>
 
             ]]>
-<![CDATA[ ]]>            
+<![CDATA[ ]]>
         </example>
     </function>
 

--- a/src/java/com/zimbra/cs/taglib/ZJspSession.java
+++ b/src/java/com/zimbra/cs/taglib/ZJspSession.java
@@ -606,4 +606,9 @@ public class ZJspSession {
         return remoteIp.getRequestIP();
     }
 
+    public static String buildRedirectURL(PageContext context, String URI) {
+        String baseURL = (String)context.getAttribute("redirectBaseURL");
+        return String.join("/", baseURL, "/".equals(URI) ? "" : URI);
+    }
+
 }

--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -17,6 +17,7 @@
 package com.zimbra.cs.taglib.tag;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ import javax.servlet.jsp.JspTagException;
 import javax.servlet.jsp.PageContext;
 
 import com.zimbra.client.ZAuthResult;
+import com.zimbra.client.ZGetInfoResult;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.service.ServiceException;
@@ -202,6 +204,16 @@ public class LoginTag extends ZimbraSimpleTag {
                         mRememberMe,
                         mbox.getAuthResult().getExpires());
             }
+            final ZGetInfoResult accountInfo = mbox.getAccountInfo(false);
+            String publicUrlBase = accountInfo.getPublicURLBase();
+            URL url = new URL(publicUrlBase);
+            if (!url.getHost().equalsIgnoreCase(request.getServerName())) {
+                publicUrlBase = request.getScheme().toLowerCase() + "://" + url.getHost();
+            } else {
+                publicUrlBase = request.getScheme().toLowerCase() + "://" + request.getServerName();
+            }
+            pageContext.setAttribute("redirectBaseURL", publicUrlBase);
+
 
             ZAuthResult authResult = mbox.getAuthResult();
             if (authResult.getTrustedToken() != null) {

--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -122,6 +122,14 @@ public class LoginTag extends ZimbraSimpleTag {
         */
     }
 
+    private String computePort(HttpServletRequest request) {
+        if ("https".equalsIgnoreCase(request.getScheme())) {
+            return request.getServerPort() == 443 ? "" : ":" + request.getServerPort();
+        } else {
+            return request.getServerPort() == 80 ? "" : ":" + request.getServerPort();
+        }
+    }
+
     @Override
     public void doTag() throws JspException, IOException {
         JspContext jctxt = getJspContext();
@@ -208,12 +216,11 @@ public class LoginTag extends ZimbraSimpleTag {
             String publicUrlBase = accountInfo.getPublicURLBase();
             URL url = new URL(publicUrlBase);
             if (!url.getHost().equalsIgnoreCase(request.getServerName())) {
-                publicUrlBase = request.getScheme().toLowerCase() + "://" + url.getHost();
+                publicUrlBase = request.getScheme().toLowerCase() + "://" + url.getHost() + computePort(request);
             } else {
-                publicUrlBase = request.getScheme().toLowerCase() + "://" + request.getServerName();
+                publicUrlBase = request.getScheme().toLowerCase() + "://" + request.getServerName() + computePort(request);
             }
             pageContext.setAttribute("redirectBaseURL", publicUrlBase);
-
 
             ZAuthResult authResult = mbox.getAuthResult();
             if (authResult.getTrustedToken() != null) {


### PR DESCRIPTION
In order to resolve the invalid Host header being used in the 'Location' response after a successful web login to prevent the ZM_AUTH_TOKEN from being sent to a hostile server the following was done:

* redirectBaseURL - is computed during the `login` and is injected into the Request Context
* buildRedirectURL - extracts the `redirectBaseURL` from the context and returns the fully qualified path to use in the redirection. This prevents the `Host` header from being used incorrectly.'
Returns `http` or `https` depending on how the request came in originally.


