### PR TITLE
NICPS-43: Restrict user to login on virtual domain

### DIFF
--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -171,7 +171,7 @@ public class LoginTag extends ZimbraSimpleTag {
 
                     // check if user domain matches current virtual host.
                     if (!virtualHost.equals(usernameSplit[1])) {
-                        throw AuthFailedServiceException.AUTH_FAILED(usernameSplit[0], "", "Invalid virtual host");
+                        throw AuthFailedServiceException.AUTH_FAILED(mUsername, "", "Invalid username for virtual host = ".concat(virtualHost));
                     }
                 }
                 options.setAccount(mUsername);

--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -164,9 +164,19 @@ public class LoginTag extends ZimbraSimpleTag {
                 options.setAuthToken(mAuthToken);
                 options.setAuthAuthToken(true);
             } else {
+                String virtualHost = getVirtualHost(request);
+
+                if (mUsername != null && !mUsername.isEmpty() && mUsername.indexOf("@") != -1) {
+                    String usernameSplit[]= mUsername.split("@");
+
+                    // check if user domain matches current virtual host.
+                    if (!virtualHost.equals(usernameSplit[1])) {
+                        throw AuthFailedServiceException.AUTH_FAILED(usernameSplit[0], "", "Invalid virtual host");
+                    }
+                }
                 options.setAccount(mUsername);
                 options.setPassword(mPassword);
-                options.setVirtualHost(getVirtualHost(request));
+                options.setVirtualHost(virtualHost);
                 if (mNewPassword != null && mNewPassword.length() > 0)
                     options.setNewPassword(mNewPassword);
             }


### PR DESCRIPTION
This PR is for ticket https://jira.corp.synacor.com/browse/NICPS-43.

Added a validation check to deny login for username with different domain other than
current virtual host in the address bar.

Error message is same as Auth failure.

A new LDAP attribute "zimbraAuthDomainCheck" to enable/disable this check will be added in another ticket/task.
