### PR TITLE
NICPS-232: Restrict user to login on virtual domain - Part 2

### DIFF
--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -157,10 +157,7 @@ public class LoginTag extends ZimbraSimpleTag {
                 options.setAuthToken(mAuthToken);
                 options.setAuthAuthToken(true);
             } else {
-                // get current virtual host
                 String virtualHost = getVirtualHost(request);
-
-                // get the ldap attribute value for zimbraAuthDomainCheckEnabled
                 boolean zimbraAuthDomainCheckEnabled = Provisioning.getInstance().getConfig().getBooleanAttr(Provisioning.A_zimbraAuthDomainCheckEnabled, false);
 
                 if (zimbraAuthDomainCheckEnabled && mUsername != null && !mUsername.isEmpty() && mUsername.indexOf("@") != -1) {

--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -41,6 +41,7 @@ import com.zimbra.common.util.HttpUtil;
 import com.zimbra.common.util.WebSplitUtil;
 import com.zimbra.common.util.ZimbraCookie;
 import com.zimbra.common.util.ngxlookup.NginxAuthServer;
+import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.taglib.ZJspSession;
 import com.zimbra.cs.taglib.ngxlookup.NginxRouteLookUpConnector;
 import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
@@ -119,14 +120,6 @@ public class LoginTag extends ZimbraSimpleTag {
 
     private String getVirtualHost(HttpServletRequest request) {
         return HttpUtil.getVirtualHost(request);
-        /*
-        String virtualHost = request.getHeader("Host");
-        if (virtualHost != null) {
-            int i = virtualHost.indexOf(':');
-            if (i != -1) virtualHost = virtualHost.substring(0, i);
-        }
-        return virtualHost;
-        */
     }
 
     @Override
@@ -164,9 +157,13 @@ public class LoginTag extends ZimbraSimpleTag {
                 options.setAuthToken(mAuthToken);
                 options.setAuthAuthToken(true);
             } else {
+                // get current virtual host
                 String virtualHost = getVirtualHost(request);
 
-                if (mUsername != null && !mUsername.isEmpty() && mUsername.indexOf("@") != -1) {
+                // get the ldap attribute value for zimbraAuthDomainCheckEnabled
+                boolean zimbraAuthDomainCheckEnabled = Provisioning.getInstance().getConfig().getBooleanAttr(Provisioning.A_zimbraAuthDomainCheckEnabled, false);
+
+                if (zimbraAuthDomainCheckEnabled && mUsername != null && !mUsername.isEmpty() && mUsername.indexOf("@") != -1) {
                     String usernameSplit[]= mUsername.split("@");
 
                     // check if user domain matches current virtual host.


### PR DESCRIPTION
This is for ticket https://jira.corp.synacor.com/browse/NICPS-232
Run 
#zmprov desc -a zimbraAuthDomainCheckEnabled 
to Verify if new LDAP attribute is available 

Run zmprov mcf zimbraAuthDomainCheckEnabled TRUE

to update the attribute value to TRUE 
Verify domain/virtualhost check is enaabled.

Run zmprov mcf zimbraAuthDomainCheckEnabled FALSE
to update the attribute value to FALSE 
Verify domain/virtualhost check is disabled.

Related PRs: https://github.com/Zimbra/zm-taglib/pull/9
https://github.com/Zimbra/zm-mailbox/pull/624
