### PR TITLE
NICPS-288: Implement Domain Virtual Host check Logic

### DIFF
--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -42,6 +42,7 @@ import com.zimbra.common.util.WebSplitUtil;
 import com.zimbra.common.util.ZimbraCookie;
 import com.zimbra.common.util.ngxlookup.NginxAuthServer;
 import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.account.Domain;
 import com.zimbra.cs.taglib.ZJspSession;
 import com.zimbra.cs.taglib.ngxlookup.NginxRouteLookUpConnector;
 import com.zimbra.cs.account.AccountServiceException.AuthFailedServiceException;
@@ -163,9 +164,12 @@ public class LoginTag extends ZimbraSimpleTag {
                 if (zimbraAuthDomainCheckEnabled && mUsername != null && !mUsername.isEmpty() && mUsername.indexOf("@") != -1) {
                     String usernameSplit[]= mUsername.split("@");
 
+                    Domain currentDomainObj = Provisioning.getInstance().getDomainByVirtualHostname(virtualHost);
+                    String currentDomainName = currentDomainObj.getDomainName();
+
                     // check if user domain matches current virtual host.
-                    if (!virtualHost.equals(usernameSplit[1])) {
-                        throw AuthFailedServiceException.AUTH_FAILED(mUsername, "", "Invalid username for host = ".concat(virtualHost));
+                    if (!currentDomainName.equals(usernameSplit[1])) {
+                        throw AuthFailedServiceException.AUTH_FAILED(mUsername, "", "Invalid username for domain = ".concat(currentDomainName));
                     }
                 }
                 options.setAccount(mUsername);


### PR DESCRIPTION
Implement Domain Virtual Host check Logic.
For e.g. if domain has virtual hosts then users should be able to login with their virtual hosts in the address bar.
xyz.com has mail.xyz.com and user1@xyz.com
zimbra.com has mail.zimbra.com and user1@zimbra.com

when on mail.xyz.com - user1@xyz.com should be able to login but user1@zimbra.com should not be able login..
when on mail.zimbra.com - user1@zimbra.com should be able to login.

