### PR TITLE
ZCS-4905 Set original user agent on login and getinfo.

### DIFF
--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -188,6 +188,7 @@ public class LoginTag extends ZimbraSimpleTag {
             if (mDeviceId != null) {
                 options.setDeviceId(mDeviceId);
             }
+            options.setOriginalUserAgent(request.getHeader("User-Agent"));
             ZMailbox mbox = ZMailbox.getMailbox(options);
             HttpServletResponse response = (HttpServletResponse) pageContext.getResponse();
 


### PR DESCRIPTION
Add original user agent header to the login/getinfo zclient requests - including the auth requests to get mailbox, and the batch request to get info.
* Fetch original User-Agent header from request (similar to how request data is already accessed).

See associated PRs
Zimbra/zm-mailbox#753
Zimbra/zm-gql#30

**Testing done**
Basic login tests and checks to verify that the information is passed along from sign in.

**Testing to be done by QA**
Login tests.