### PR TITLE
ZCS-6201:Doesn't work zauthtoken on split environment

### DIFF
--- a/src/java/com/zimbra/cs/taglib/ZJspSession.java
+++ b/src/java/com/zimbra/cs/taglib/ZJspSession.java
@@ -477,10 +477,14 @@ public class ZJspSession {
 
         HttpServletRequest request= (HttpServletRequest) context.getRequest();
         ZAuthToken zat = new ZAuthToken(request, false);
-        if (zat.isEmpty())
-            return null;
-        else
+        if (!zat.isEmpty()) {
             return zat;
+        }
+        zat = new ZAuthToken((String) request.getParameter(Q_ZAUTHTOKEN));
+        if (!zat.isEmpty()) {
+            return zat;
+        }
+        return null;
     }
 
     public static boolean hasSession(PageContext context) {


### PR DESCRIPTION
[Problem]
End user can't login using SSO token "zauthtoken" if the environment is configured with Web-split mode.

When the end user tries to login via URL something like "https://{proxy-fqdn}/?zauthtoken={authtoken-value}", if the Web UI and backend mailbox server resident on the same server, he/she can login.  But if the system is configured with Web-split mode, he/she can't due to the "auth required" error on the login screen.

The zauthtoken parameter should work whatever the system configuration is.

[Root cause]
The value of the zauthtoken parameter on the URL was ignored when the UI server was running on the separate host than the mailbox server.

If the UI and the backend mailbox servers are running on the separate hosts, when the end user is log-in, the UI server needs to choose the connecting backend server based on the user info.  When the user info is passed only via zauthtoken, the UI server should have parsed it to extract the user ID to look up the LDAP, but it didn't.  As a result, the UI server couldn't find the upstream mailbox server for the accessing end user, and he/she got "Auth required" error message.

[Fix]
Add to check "zauthtoken" parameter passed via URL if the authentication token is not found in the cookie.