### PR TITLE
ZBUG-696: Web-split:NPE thrown by unknown account at login

### DIFF
--- a/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/LoginTag.java
@@ -31,10 +31,13 @@ import com.zimbra.client.ZAuthResult;
 import com.zimbra.client.ZMailbox;
 import com.zimbra.common.auth.ZAuthToken;
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.SoapFaultException;
 import com.zimbra.common.util.HttpUtil;
 import com.zimbra.common.util.WebSplitUtil;
 import com.zimbra.common.util.ZimbraCookie;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.common.util.ngxlookup.NginxAuthServer;
+import com.zimbra.cs.account.AccountServiceException;
 import com.zimbra.cs.taglib.ZJspSession;
 import com.zimbra.cs.taglib.ngxlookup.NginxRouteLookUpConnector;
 
@@ -163,9 +166,14 @@ public class LoginTag extends ZimbraSimpleTag {
                     String protocol = (ZJspSession.isProtocolModeHttps() ? "httpssl" : "http");
                     NginxAuthServer nginxLookUpServer = NginxRouteLookUpConnector.getClient().getRouteforAccount(mUsername, "username",
                             protocol, HttpUtil.getVirtualHost(request), request.getRemoteAddr(), request.getHeader("Virtual-Host"));
-                    // In case of https, protocol needs to be https for the URL and not httpssl as passed to getRouteforAccount
-                    protocol = (ZJspSession.isProtocolModeHttps() ? "https" : "http");
-                    mUrl = protocol + "://" + nginxLookUpServer.getNginxAuthServer() + "/service/soap";
+                    if (null == nginxLookUpServer) {
+                        throw new SoapFaultException("Nginx route lookup error: Authentication failed for [" + mUsername + "]",
+                                AccountServiceException.AUTH_FAILED, false, null);
+                    } else {
+                        // In case of https, protocol needs to be https for the URL and not httpssl as passed to getRouteforAccount
+                        protocol = (ZJspSession.isProtocolModeHttps() ? "https" : "http");
+                        mUrl = protocol + "://" + nginxLookUpServer.getNginxAuthServer() + "/service/soap";
+                    }
                 } else {
                     mUrl = ZJspSession.getSoapURL(pageContext);
                 }


### PR DESCRIPTION
[Problem]
NullPointerException was thrown on the UI server side when logging in with a non-existing account on the multi-server web-split environment.  AS a result, "A client error occurred. Please try again." was shown in login page. Because this was caused by the lack of valid login ID, "The username or password is incorrect. Verify that CAPS LOCK is not on, and then retype the current username and password." error message should be displayed.

[Root cause]
When the environment is enabled to the WebClient split installation, the UI server submits to the RoutingLookupService running on the backend mailbox server.  The backend mailbox server looks up the account name to the LDAP and return the host info for the further SOAP request.　
The UI server creates a "server object" based on the response from the backend server; but the UI server didn’t take account into the fact that the “server object” could be null when the backend mailbox server didn’t find any info of the requested account.

[Fix]
Added the code to check whether the returned "server object" (nginxLookUpServer local variable) is null before accessing it.
(note) If the backend servers are all down, NginxRouteLookUpConnector.getClient().getRouteforAccount() method throws the ServiceException and the error will be handled properly (that part of the code has already worked as expected).

[Affected area]
Login tag for all client