### PR TITLE
ZCS-8016: updating commons fileupload version from 1.2.2 to 1.4

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -14,7 +14,7 @@
   <dependency org="org.apache.httpcomponents" name="httpmime" rev="${httpclient.version}"/>
   <dependency org="com.google.guava" name="guava" rev="23.0" />
   <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.2-zimbra" />
-  <dependency org="commons-fileupload" name="commons-fileupload" rev="1.2.2" />
+  <dependency org="commons-fileupload" name="commons-fileupload" rev="1.4" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />
   <dependency org="net.spy" name="spymemcached" rev="2.12.1" transitive="false"/>
   <dependency org="org.eclipse.jetty" name="jetty-io" rev="9.3.5.v20151012" />


### PR DESCRIPTION
Issue:
commons-fileupload older version have vulnerabilities.

Fix:
Updating version from 1.2.2 to 1.4

Related PRs:
https://github.com/Zimbra/zm-mailbox/pull/980
https://github.com/Zimbra/zm-zcs-lib/pull/56
https://github.com/Zimbra/zm-genesis/pull/40
https://github.com/Zimbra/zm-soap-harness/pull/93
https://github.com/Zimbra/zm-clientuploader-store/pull/3
https://github.com/Zimbra/zm-clam-scanner-store/pull/2