### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0 and centrally

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -12,7 +12,7 @@
   <dependency org="commons-codec" name="commons-codec" rev="1.7" />
   <dependency org="org.apache.httpcomponents" name="httpclient" rev="${httpclient.version}"/>
   <dependency org="org.apache.httpcomponents" name="httpmime" rev="${httpclient.version}"/>
-  <dependency org="com.google.guava" name="guava" rev="23.0" />
+  <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
   <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.2-zimbra" />
   <dependency org="commons-fileupload" name="commons-fileupload" rev="1.4" />
   <dependency org="javax.mail" name="mail" rev="1.4.5" />


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally