### PR TITLE
ZBUG-896: Try to get host from username

### DIFF
--- a/src/java/com/zimbra/cs/taglib/bean/BeanUtils.java
+++ b/src/java/com/zimbra/cs/taglib/bean/BeanUtils.java
@@ -659,6 +659,15 @@ public class BeanUtils {
 
     public static String getServerName(PageContext pc) {
 		String serverName = pc.getRequest().getParameter("customerDomain");
+		String userName = pc.getRequest().getParameter("username");
+
+		if (serverName == null && userName != null) {
+			int atIdx = userName.indexOf("@");
+			if (atIdx != -1) {
+				serverName = userName.substring(atIdx+1);
+			}
+		}
+
         return serverName != null ? serverName.trim() : HttpUtil.getVirtualHost((HttpServletRequest) pc.getRequest());
     }
     


### PR DESCRIPTION
**Problem**
During login/logout in classic web UI, the code does not have access to the specific domain of the user.

**Fix**
For the GetDomainInfo and other JSP tags, attempt to derive domain from username.

**See Also**
https://github.com/Zimbra/zm-web-client/pull/695