### PR TITLE
ZCS-12546: added functions to use custom date time format

### DIFF
--- a/META-INF/zm.tld
+++ b/META-INF/zm.tld
@@ -7196,6 +7196,13 @@
     </function>
 
     <function>
+        <name>displayMsgDateWithTemplate</name>
+        <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
+        <function-signature>java.lang.String
+            displayMsgDate(javax.servlet.jsp.PageContext,java.util.Date, java.lang.String, java.lang.String)</function-signature>
+    </function>
+
+    <function>
         <name>displayVoiceDate</name>
         <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
         <function-signature>java.lang.String
@@ -7207,6 +7214,13 @@
         <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
         <function-signature>java.lang.String
             displayDate(javax.servlet.jsp.PageContext,java.util.Date)</function-signature>
+    </function>
+
+    <function>
+        <name>displayDateWithTemplate</name>
+        <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
+        <function-signature>java.lang.String
+            displayDate(javax.servlet.jsp.PageContext,java.util.Date,java.lang.String)</function-signature>
     </function>
 
     <function>
@@ -7777,9 +7791,21 @@
     </function>
 
     <function>
+        <name>getRepeatBlurbWithTemplate</name>
+        <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
+        <function-signature>java.lang.String getRepeatBlurb(com.zimbra.client.ZSimpleRecurrence,javax.servlet.jsp.PageContext,java.util.TimeZone,java.util.Date,java.lang.String)</function-signature>
+    </function>
+
+    <function>
         <name>getApptDateBlurb</name>
         <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
         <function-signature>java.lang.String getApptDateBlurb(javax.servlet.jsp.PageContext,java.util.TimeZone,long,long,boolean)</function-signature>
+    </function>
+
+    <function>
+        <name>getApptDateBlurbWithTemplate</name>
+        <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
+        <function-signature>java.lang.String getApptDateBlurb(javax.servlet.jsp.PageContext,java.util.TimeZone,long,long,boolean,java.lang.String,java.lang.String)</function-signature>
     </function>
 
     <function>


### PR DESCRIPTION
Overload the following functions to return custom date time format:
* displayMsgDate
* displayDate
* getRepeatBlurb
* getApptDateBlurb

For example, when printappointments is modified as follows,
```
$ pwd
/opt/zimbra/jetty/webapps/zimbra/h

$ diff printappointments.bkp printappointments
166c166
<         ${fn:escapeXml(zm:getApptDateBlurb(pageContext, tz, startDate.time, endDate.time, appt.allDay))}
---
>         ${fn:escapeXml(zm:getApptDateBlurbWithTemplate(pageContext, tz, startDate.time, endDate.time, appt.allDay, "ZM_formatDateFull", "ZM_formatTimeMedium"))}
223c223
<                 ${fn:escapeXml(zm:getRepeatBlurb(repeat,pageContext,tz, appt.start.date))}
---
>                 ${fn:escapeXml(zm:getRepeatBlurbWithTemplate(repeat,pageContext,tz, appt.start.date, "ZM_formatDateFull"))}

$ vi /opt/zimbra/jetty/webapps/zimbra/WEB-INF/classes/messages/ZhMsg.properties
(adding the following items)
ZM_formatDateFull = yyyy/MM/dd(EEE)
ZM_formatTimeMedium = HH:mm
``` 
print appointment page is changed as below.
(original)
![print_appointment_original](https://user-images.githubusercontent.com/32184593/202952226-17dd6e00-4f12-488f-865f-8ac787c172a3.png)

(with custom template)
![print_appointment_custom](https://user-images.githubusercontent.com/32184593/202952248-3f661a4d-a3c3-4e1a-a767-a1ecdefc2adf.png)

Note that `displayMsgDate` and `displayDate` were used in Standard HTML client and Mobile HTML client. They are no longer available, but the taglib functions are still necessary for some customers.