### PR TITLE
ZCS-12712: added isDomainLoginPageEnabled to BeanUtils

### DIFF
--- a/META-INF/zm.tld
+++ b/META-INF/zm.tld
@@ -7365,6 +7365,18 @@
 	</function>
 
     <function>
+        <name>isDomainLoginPageEnabled</name>
+        <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
+        <function-signature>boolean isDomainLoginPageEnabled()</function-signature>
+    </function>
+
+    <function>
+        <name>getDomainLoginPageErrorPath</name>
+        <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
+        <function-signature>boolean getDomainLoginPageErrorPath()</function-signature>
+    </function>
+
+    <function>
         <name>getAddressBook</name>
         <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
         <function-signature>com.zimbra.client.ZFilterCondition.ZAddressBookCondition getAddressBook(com.zimbra.client.ZFilterCondition)</function-signature>

--- a/src/java/com/zimbra/cs/taglib/bean/BeanUtils.java
+++ b/src/java/com/zimbra/cs/taglib/bean/BeanUtils.java
@@ -577,6 +577,16 @@ public class BeanUtils {
        return prov.getConfig().getBooleanAttr(attr, false) || ProvisioningConstants.TRUE.equals(getAttr(pc, attr));
    }
 
+   public static boolean isDomainLoginPageEnabled() throws JspException, ServiceException {
+       Provisioning prov = Provisioning.getInstance();
+       return prov.getConfig().isDomainLoginPageEnabled();
+   }
+
+   public static String getDomainLoginPageErrorPath() throws JspException, ServiceException {
+       Provisioning prov = Provisioning.getInstance();
+       return prov.getConfig().getDomainLoginPageErrorPath();
+   }
+
     public static String getMailURL(PageContext pc) {
         try {
             return Provisioning.getInstance().getLocalServer().getMailURL();


### PR DESCRIPTION
Add functions to return the value of global config `zimbraDomainLoginPageEnabled` and `zimbraDomainLoginPageErrorPath`.

**Related PRs:**
* https://github.com/Zimbra/zm-mailbox/pull/1432
* https://github.com/Zimbra/zm-web-client/pull/772