### PR TITLE
ZCS-13306: added derefGroupMember to GetAllContactsTag for print

### DIFF
--- a/META-INF/zm.tld
+++ b/META-INF/zm.tld
@@ -2190,6 +2190,13 @@
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
+
+        <attribute>
+            <description>derefContactGroupMember</description>
+            <name>derefGroupMember</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
     </tag>
 
     <tag>

--- a/src/java/com/zimbra/cs/taglib/tag/contact/GetAllContactsTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/contact/GetAllContactsTag.java
@@ -36,18 +36,20 @@ public class GetAllContactsTag extends ZimbraSimpleTag {
     private String mFolderId;
     private String mContactIds;
     private boolean mSync;
+    private boolean mDerefGroupMember;
 
     public void setVar(String var) { this.mVar = var; }
     public void setFolderId(String folderid) { this.mFolderId = folderid; }
     public void setContactIds(String ids) { this.mContactIds = ids; }
     public void setSync(boolean sync) { this.mSync = sync; }
+    public void setDerefGroupMember(boolean derefGroupMember) { this.mDerefGroupMember = derefGroupMember; }
 
     public void doTag() throws JspException, IOException {
         JspContext jctxt = getJspContext();
         try {
             ZMailbox mbox = getMailbox();
             List<ZContactBean> contactBeanList = new ArrayList<ZContactBean>();
-            List<ZContact> contactList = mbox.getContactsForFolder(mFolderId, mContactIds, null, false, null);
+            List<ZContact> contactList = mbox.getContactsForFolder(mFolderId, mContactIds, null, false, null, mDerefGroupMember);
             for(ZContact contact: contactList) {
               contactBeanList.add(new ZContactBean(contact));
             }


### PR DESCRIPTION
Adding `derefGroupMember` attribute to GetAllContactsTag (called from a jsp as `zm:getAllContacts`) so that members of a contact group is shown in Print Contact page on Classic UI.

**Related PRs:**
* https://github.com/Zimbra/zm-mailbox/pull/1510
* https://github.com/Zimbra/zm-web-client/pull/832