### PR TITLE
ZCS-14436: changed to get status of SendTwoFactorAuthCodeResponse from element

### DIFF
--- a/src/java/com/zimbra/cs/taglib/tag/SendTwoFactorAuthCodeTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/SendTwoFactorAuthCodeTag.java
@@ -90,7 +90,7 @@ public class SendTwoFactorAuthCodeTag extends ZimbraSimpleTag {
 
             ZimbraLog.webclient.debug("SendTwoFactorAuthCodeRequest with action=" + action + " and method=" + mMethod);
             Element resp = transport.invokeWithoutSession(req);
-            String status = resp.getAttribute(AccountConstants.A_STATUS);
+            String status = resp.getElement(AccountConstants.A_STATUS).getText();
             if ((AccountConstants.E_TWO_FACTOR_METHOD_APP.equals(mMethod) &&
                     SendTwoFactorAuthCodeStatus.RESET_FAILED.toString().equals(status)) ||
                 (AccountConstants.E_TWO_FACTOR_METHOD_EMAIL.equals(mMethod) &&


### PR DESCRIPTION
**Background:**
SendTwoFactorAuthRequest and Response have been updated on https://github.com/Zimbra/zm-mailbox/pull/1545
* `action` of SendTwoFactorAuthRequest is specified as an element.
* `status` of SendTwoFactorAuthResponse is returned as an element.

**Change:**
* fetch the `status` from an element 
* no update about `action`. It has already been set as an element.
   ```
   req.addUniqueElement(AccountConstants.E_ACTION).setText(action);
   ```