### PR TITLE
ZCS-14531: merge TFA email method support to develop

### DIFF
--- a/META-INF/zm.tld
+++ b/META-INF/zm.tld
@@ -6942,6 +6942,109 @@
         </attribute>
     </tag>
 
+    <tag>
+        <description>
+            get configuration for two-factor authentication (TFA)
+        </description>
+        <name>getTwoFactorAuthConfig</name>
+        <tag-class>com.zimbra.cs.taglib.tag.GetTwoFactorAuthConfigTag</tag-class>
+        <body-content>empty</body-content>
+        <attribute>
+            <description>ZAuthResult object to use</description>
+            <name>authResult</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+            <type>com.zimbra.client.ZAuthResult</type>
+        </attribute>
+        <attribute>
+            <description>
+                exception to check if TFA setup is required
+            </description>
+            <name>exception</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+            <type>com.zimbra.cs.taglib.bean.ZExceptionBean</type>
+        </attribute>
+        <attribute>
+            <description>
+                username to check if TFA setup is required
+            </description>
+            <name>username</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                variable to store allowed TFA method(s)
+            </description>
+            <name>varTFAMethodAllowed</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description>
+                variable to store enabled TFA method(s)
+            </description>
+            <name>varTFAMethodEnabled</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description>
+                variable to store a TFA method to be used
+            </description>
+            <name>varMethod</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description>
+                variable to store a masked email address
+            </description>
+            <name>varMaskedEmailAddress</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description>
+                variable to store whether reset password feature is enabled and recovery email address is verified
+            </description>
+            <name>varResetPasswordEnabled</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+
+    <tag>
+        <description>
+            call SendTwoFactorAuthCodeRequest
+        </description>
+        <name>sendTwoFactorAuthCode</name>
+        <tag-class>com.zimbra.cs.taglib.tag.SendTwoFactorAuthCodeTag</tag-class>
+        <body-content>empty</body-content>
+        <attribute>
+            <description>varResult</description>
+            <name>varResult</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description>method</description>
+            <name>method</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>authResult</description>
+            <name>authResult</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+            <type>com.zimbra.client.ZAuthResult</type>
+        </attribute>
+    </tag>
+
 	<!-- These tags are copied from jstl.tld because we implement our own
 	     versions but want to keep API compatibility. -->
 	<!--
@@ -8124,5 +8227,11 @@
 		<function-class>com.zimbra.common.util.StringUtil</function-class>
         <function-signature>java.lang.String nonNull(java.lang.String)</function-signature>
 	</function>
+
+    <function>
+        <name>isTwoFactorAuthRequired</name>
+        <function-class>com.zimbra.cs.taglib.bean.BeanUtils</function-class>
+        <function-signature>java.lang.Boolean isTwoFactorAuthRequired(javax.servlet.jsp.PageContext)</function-signature>
+    </function>
 
 </taglib>

--- a/src/java/com/zimbra/cs/taglib/tag/GetTwoFactorAuthConfigTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/GetTwoFactorAuthConfigTag.java
@@ -1,0 +1,143 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.taglib.tag;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.zimbra.client.ZAuthResult;
+import com.zimbra.common.account.ZAttrProvisioning;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.util.StringUtil;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.AccountServiceException;
+import com.zimbra.cs.account.soap.SoapProvisioning;
+import com.zimbra.cs.taglib.bean.BeanUtils;
+import com.zimbra.cs.taglib.bean.ZExceptionBean;
+
+public class GetTwoFactorAuthConfigTag extends ZimbraSimpleTag {
+
+    private ZAuthResult authResult;
+    private ZExceptionBean exception;
+    private String username;
+    private String mVarTFAMethodAllowed;
+    private String mVarTFAMethodEnabled;
+    private String mVarMethod;
+    private String mVarMaskedEmailAddress;
+    private String mVarResetPasswordEnabled;
+
+    private String defaultMethod = AccountConstants.E_TWO_FACTOR_METHOD_APP;
+    private String[] defaultMethodOrder = new String[] {
+        AccountConstants.E_TWO_FACTOR_METHOD_APP,
+        AccountConstants.E_TWO_FACTOR_METHOD_EMAIL
+    };
+
+    public void setAuthResult(ZAuthResult authResult) { this.authResult = authResult; }
+
+    public void setException(ZExceptionBean exception) { this.exception = exception; }
+
+    public void setUsername(String username) { this.username = username; }
+
+    public void setVarTFAMethodAllowed(String varTFAMethodAllowed) { this.mVarTFAMethodAllowed = varTFAMethodAllowed; }
+
+    public void setVarTFAMethodEnabled(String varTFAMethodEnabled) { this.mVarTFAMethodEnabled = varTFAMethodEnabled; }
+
+    public void setVarMethod(String varMethod) { this.mVarMethod = varMethod; }
+
+    public void setVarMaskedEmailAddress(String varMaskedEmailAddress) { this.mVarMaskedEmailAddress = varMaskedEmailAddress; }
+
+    public void setVarResetPasswordEnabled(String varResetPasswordEnabled) { this.mVarResetPasswordEnabled = varResetPasswordEnabled; }
+
+    @Override
+    public void doTag() {
+        try {
+            List<String> twoFactorAuthMethodAllowed;
+            List<String> twoFactorAuthMethodEnabled;
+            String primaryTwoFactorAuthMethod;
+            String maskedPasswordRecoveryAddress;
+
+            if (authResult != null) {
+                twoFactorAuthMethodAllowed = authResult.getTwoFactorAuthMethodAllowed();
+                twoFactorAuthMethodEnabled = authResult.getTwoFactorAuthMethodEnabled();
+                primaryTwoFactorAuthMethod = authResult.getPrimaryTwoFactorAuthMethod();
+                maskedPasswordRecoveryAddress = authResult.getMaskedPasswordRecoveryAddress();
+
+                // backward compatibility
+                if (twoFactorAuthMethodAllowed == null || twoFactorAuthMethodAllowed.size() == 0) {
+                    twoFactorAuthMethodAllowed = Arrays.asList(defaultMethod);
+                }
+                if (authResult.getTwoFactorAuthRequired() &&
+                        (twoFactorAuthMethodEnabled == null || twoFactorAuthMethodEnabled.size() == 0)) {
+                    twoFactorAuthMethodEnabled = Arrays.asList(defaultMethod);
+                }
+
+                List<String> allowedAndEnabledMethodSorted = new ArrayList<String>();
+                for (String method: defaultMethodOrder) {
+                    if (twoFactorAuthMethodAllowed.contains(method) && twoFactorAuthMethodEnabled.contains(method)) {
+                        if (AccountConstants.E_TWO_FACTOR_METHOD_EMAIL.equals(method) &&
+                                StringUtil.isNullOrEmpty(maskedPasswordRecoveryAddress)) {
+                            // email method is unavailable when no valid email has been set.
+                            continue;
+                        }
+                        allowedAndEnabledMethodSorted.add(method);
+                    }
+                }
+                getJspContext().setAttribute(mVarTFAMethodEnabled, String.join(",", allowedAndEnabledMethodSorted));
+
+                if (!StringUtil.isNullOrEmpty(primaryTwoFactorAuthMethod) &&
+                        allowedAndEnabledMethodSorted.contains(primaryTwoFactorAuthMethod)) {
+                    getJspContext().setAttribute(mVarMethod, primaryTwoFactorAuthMethod);
+                } else if (allowedAndEnabledMethodSorted.size() != 0) {
+                    getJspContext().setAttribute(mVarMethod, allowedAndEnabledMethodSorted.get(0));
+                }
+
+                if (allowedAndEnabledMethodSorted.contains(AccountConstants.E_TWO_FACTOR_METHOD_EMAIL)) {
+                    getJspContext().setAttribute(mVarMaskedEmailAddress, BeanUtils.cook(maskedPasswordRecoveryAddress));
+                }
+            } else if (exception != null && AccountServiceException.TWO_FACTOR_SETUP_REQUIRED.equals(exception.getCode())) {
+                SoapProvisioning sp = SoapProvisioning.getAdminInstance();
+                Account account = sp.getAccount(username, true);
+                String[] twoFactorAuthMethodAllowedStringArray = account.getTwoFactorAuthMethodAllowed();
+
+                // backward compatibility
+                if (twoFactorAuthMethodAllowedStringArray == null || twoFactorAuthMethodAllowedStringArray.length == 0) {
+                    twoFactorAuthMethodAllowedStringArray = new String[]{ defaultMethod };
+                }
+
+                twoFactorAuthMethodAllowed = Arrays.asList(twoFactorAuthMethodAllowedStringArray);
+                List<String> allowedMethodSorted = new ArrayList<String>();
+                for (String method: defaultMethodOrder) {
+                    if (twoFactorAuthMethodAllowed.contains(method)) {
+                        allowedMethodSorted.add(method);
+                    }
+                }
+                ZAttrProvisioning.FeatureResetPasswordStatus featureResetPasswordStatue = account.getFeatureResetPasswordStatus();
+                ZAttrProvisioning.PrefPasswordRecoveryAddressStatus prefPasswordRecoveryAddressStatus = account.getPrefPasswordRecoveryAddressStatus();
+                boolean isResetPasswordEnabled = (featureResetPasswordStatue != null && featureResetPasswordStatue.isEnabled() &&
+                                                  prefPasswordRecoveryAddressStatus != null && prefPasswordRecoveryAddressStatus.isVerified());
+                getJspContext().setAttribute(mVarTFAMethodAllowed, String.join(",", allowedMethodSorted));
+                getJspContext().setAttribute(mVarResetPasswordEnabled, isResetPasswordEnabled);
+            } else {
+                ZimbraLog.webclient.warn("No valid authResult or exception was passed");
+            }
+        } catch (Exception e) {
+            ZimbraLog.webclient.warn("Configuration for two-factor authentication could not be fetched");
+        }
+    }
+}

--- a/src/java/com/zimbra/cs/taglib/tag/SendTwoFactorAuthCodeTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/SendTwoFactorAuthCodeTag.java
@@ -1,0 +1,108 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2023 Zimbra, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.cs.taglib.tag;
+
+import java.io.IOException;
+
+import javax.servlet.jsp.JspContext;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
+
+import com.zimbra.client.ZAuthResult;
+import com.zimbra.common.auth.ZAuthToken;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.Element.XMLElement;
+import com.zimbra.common.soap.SoapHttpTransport;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.taglib.ZJspSession;
+import com.zimbra.cs.taglib.bean.BeanUtils;
+import com.zimbra.soap.account.message.SendTwoFactorAuthCodeRequest.SendTwoFactorAuthCodeAction;
+import com.zimbra.soap.account.message.SendTwoFactorAuthCodeResponse.SendTwoFactorAuthCodeStatus;
+
+public class SendTwoFactorAuthCodeTag extends ZimbraSimpleTag {
+
+    private String mVarResult;
+    private String mMethod;
+    private ZAuthResult authResult;
+
+    public void setVarResult(String varResult) { this.mVarResult = varResult; }
+    public void setMethod(String method) { this.mMethod = method; }
+    public void setAuthResult(ZAuthResult authResult) { this.authResult = authResult; }
+
+    public void doTag() throws JspException, IOException {
+        String action = "";
+        try {
+            JspContext jctxt = getJspContext();
+            PageContext pageContext = (PageContext) jctxt;
+            ZAuthToken zAuthToken;
+            String authtoken;
+
+            if (authResult != null) {
+                // no authtoken is included in a http request just after login with username and password.
+                // authtoken needs to be fetched from ZAuthResult
+                zAuthToken = authResult.getAuthToken();
+            } else {
+                // ZAuthResult is empty when a TFA method is changed on login page.
+                // check authtoken in a http request
+                zAuthToken = ZJspSession.getAuthToken(pageContext);
+            }
+
+            if (!BeanUtils.isTwoFactorAuthRequired(zAuthToken)) {
+                ZimbraLog.webclient.warn("Invalid authtoken was used to call SendTwoFactorAuthCodeRequest");
+                getJspContext().setAttribute(mVarResult, "failed");
+                return;
+            }
+
+            if (AccountConstants.E_TWO_FACTOR_METHOD_APP.equals(mMethod)) {
+                action = SendTwoFactorAuthCodeAction.RESET.toString();
+            } else if (AccountConstants.E_TWO_FACTOR_METHOD_EMAIL.equals(mMethod)) {
+                action = SendTwoFactorAuthCodeAction.EMAIL.toString();
+            } else {
+                ZimbraLog.webclient.info("Configuration for two-factor authentication failed. Unsupported method: " + mMethod);
+                getJspContext().setAttribute(mVarResult, "failed");
+                return;
+            }
+
+            String soapUri = ZJspSession.getSoapURL(pageContext);
+            authtoken = zAuthToken.getValue();
+
+            SoapHttpTransport transport = new SoapHttpTransport(soapUri);
+            XMLElement req = new XMLElement(AccountConstants.E_SEND_TWO_FACTOR_AUTH_CODE_REQUEST);
+            req.addAttribute(XMLElement.A_NAMESPACE, AccountConstants.NAMESPACE_STR);
+            req.addUniqueElement(AccountConstants.E_ACTION).setText(action);
+            req.addUniqueElement(AccountConstants.E_AUTH_TOKEN).setText(authtoken);
+
+            ZimbraLog.webclient.debug("SendTwoFactorAuthCodeRequest with action=" + action + " and method=" + mMethod);
+            Element resp = transport.invokeWithoutSession(req);
+            String status = resp.getAttribute(AccountConstants.A_STATUS);
+            if ((AccountConstants.E_TWO_FACTOR_METHOD_APP.equals(mMethod) &&
+                    SendTwoFactorAuthCodeStatus.RESET_FAILED.toString().equals(status)) ||
+                (AccountConstants.E_TWO_FACTOR_METHOD_EMAIL.equals(mMethod) &&
+                    SendTwoFactorAuthCodeStatus.NOT_SENT.toString().equals(status))) {
+                ZimbraLog.webclient.warn("Configuration for two-factor authentication failed. method=" + mMethod + " action=" + action);
+                getJspContext().setAttribute(mVarResult, "failed");
+            } else {
+                getJspContext().setAttribute(mVarResult, "succeeded");
+            }
+        } catch (ServiceException e) {
+            ZimbraLog.webclient.warn("Two-factor authentication could not be executed.");
+            getJspContext().setAttribute(mVarResult, "failed");
+        }
+    }
+}

--- a/src/java/com/zimbra/cs/taglib/tag/SendTwoFactorAuthCodeTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/SendTwoFactorAuthCodeTag.java
@@ -90,7 +90,7 @@ public class SendTwoFactorAuthCodeTag extends ZimbraSimpleTag {
 
             ZimbraLog.webclient.debug("SendTwoFactorAuthCodeRequest with action=" + action + " and method=" + mMethod);
             Element resp = transport.invokeWithoutSession(req);
-            String status = resp.getAttribute(AccountConstants.A_STATUS);
+            String status = resp.getElement(AccountConstants.A_STATUS).getText();
             if ((AccountConstants.E_TWO_FACTOR_METHOD_APP.equals(mMethod) &&
                     SendTwoFactorAuthCodeStatus.RESET_FAILED.toString().equals(status)) ||
                 (AccountConstants.E_TWO_FACTOR_METHOD_EMAIL.equals(mMethod) &&

--- a/src/java/com/zimbra/cs/taglib/tag/SendTwoFactorAuthCodeTag.java
+++ b/src/java/com/zimbra/cs/taglib/tag/SendTwoFactorAuthCodeTag.java
@@ -83,10 +83,11 @@ public class SendTwoFactorAuthCodeTag extends ZimbraSimpleTag {
             authtoken = zAuthToken.getValue();
 
             SoapHttpTransport transport = new SoapHttpTransport(soapUri);
+            transport.setAuthToken(authtoken);
+
             XMLElement req = new XMLElement(AccountConstants.E_SEND_TWO_FACTOR_AUTH_CODE_REQUEST);
             req.addAttribute(XMLElement.A_NAMESPACE, AccountConstants.NAMESPACE_STR);
             req.addUniqueElement(AccountConstants.E_ACTION).setText(action);
-            req.addUniqueElement(AccountConstants.E_AUTH_TOKEN).setText(authtoken);
 
             ZimbraLog.webclient.debug("SendTwoFactorAuthCodeRequest with action=" + action + " and method=" + mMethod);
             Element resp = transport.invokeWithoutSession(req);


### PR DESCRIPTION
The PR is merging all changes for two factor authentication email method support into `develop`.

`feature/2FAEmailCode` has been rebased to the latest `develop`.
No conflict occurred during the rebase.
No additional change exists.