### PR TITLE
ZBUG-5635: Password Expiration / New Password Prompt Not showing the complete password policy requirements

### DIFF
--- a/src/java/com/zimbra/cs/taglib/bean/BeanUtils.java
+++ b/src/java/com/zimbra/cs/taglib/bean/BeanUtils.java
@@ -2107,7 +2107,9 @@ public class BeanUtils {
                 ZAttrProvisioning.A_zimbraPasswordMinDigitsOrPuncs,
                 ZAttrProvisioning.A_zimbraFeatureAllowUsernameInPassword,
                 ZAttrProvisioning.A_zimbraPasswordAllowedChars,
-                ZAttrProvisioning.A_zimbraPasswordAllowedPunctuationChars
+                ZAttrProvisioning.A_zimbraPasswordAllowedPunctuationChars,
+                ZAttrProvisioning.A_zimbraPasswordEnforceHistory,
+                ZAttrProvisioning.A_zimbraPasswordBlockCommonEnabled
         };
         return attributes;
     }


### PR DESCRIPTION
Added `zimbraPasswordEnforceHistory` and `PasswordBlockCommonEnabled` attributes to the `getPasswordConfigAttrs` method.